### PR TITLE
feat: convert toc to hamburger menu

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -30,21 +30,39 @@
   .main-grid {
     grid-template-columns: 1fr;
   }
+}
 
-  .toc {
-    order: -1;
-  }
+.toc-toggle {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 201;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: .5rem;
+  box-shadow: var(--shadow);
 }
 
 .toc {
-  position: sticky;
-  top: 4.5rem;
-  align-self: start;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 260px;
+  max-width: 80%;
+  transform: translateX(-110%);
+  transition: transform .3s;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1rem;
   background: var(--surface);
   box-shadow: var(--shadow);
+  z-index: 200;
+}
+
+.toc.open {
+  transform: translateX(0);
 }
 
 .toc nav a {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,7 +8,29 @@ import { setYear } from "./accessibility.js";
 
 const app = qs("#app");
 const tocNav = qs("#toc-nav");
+const tocAside = qs("#toc");
+const tocToggle = qs("#toc-toggle");
 const yearNode = qs("#year");
+
+const closeToc = () => {
+  tocAside.classList.remove("open");
+  tocAside.setAttribute("aria-hidden", "true");
+  tocToggle.setAttribute("aria-expanded", "false");
+};
+
+const toggleToc = () => {
+  const open = tocAside.classList.toggle("open");
+  tocAside.setAttribute("aria-hidden", String(!open));
+  tocToggle.setAttribute("aria-expanded", String(open));
+};
+
+if (tocToggle) listen(tocToggle, "click", toggleToc);
+
+document.addEventListener("click", (e) => {
+  if (!tocAside.classList.contains("open")) return;
+  if (e.target.closest("#toc") || e.target.closest("#toc-toggle")) return;
+  closeToc();
+});
 
 setYear(yearNode);
 
@@ -51,6 +73,7 @@ listen(tocNav, "click", (e) => {
   const url = new URL(location.href);
   url.hash = id;
   history.replaceState(null, "", url);
+  closeToc();
 });
 
 const sectionIds = ["about", "social", "works"];

--- a/index.html
+++ b/index.html
@@ -13,12 +13,14 @@
   <body>
     <a class="skip-link" href="#about">Skip to content</a>
 
-    <div class="container main-grid">
-      <aside class="toc" aria-label="Table of contents">
-        <h2 id="toc-title">目次</h2>
-        <nav id="toc-nav"></nav>
-      </aside>
+    <button id="toc-toggle" class="toc-toggle" aria-label="Toggle table of contents" aria-controls="toc" aria-expanded="false">☰</button>
 
+    <aside id="toc" class="toc" aria-label="Table of contents" aria-hidden="true">
+      <h2 id="toc-title">目次</h2>
+      <nav id="toc-nav"></nav>
+    </aside>
+
+    <div class="container">
       <main id="app" class="content" role="main" tabindex="-1">
         <noscript>
           <p>This page needs JavaScript enabled.</p>


### PR DESCRIPTION
## Summary
- replace always-visible table of contents with hamburger toggle
- add JS logic to open/close menu and auto-hide on link selection or outside click
- style TOC overlay and toggle button

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689d53f817e483238b695d5e9f65372d